### PR TITLE
smart home: replace hardcoded impls for Thermometer and Plugs with trait objects

### DIFF
--- a/src/device/hardcoded_devices.rs
+++ b/src/device/hardcoded_devices.rs
@@ -1,0 +1,115 @@
+#![allow(dead_code)]
+/// only for examples
+use std::cell::Cell;
+
+use crate::{SmartDevice, SmartPlug, SmartThermometer};
+
+/// Thermometer for the tests
+pub(crate) struct ExampleThermometer {
+    current_temperature: Cell<f64>,
+    name: String,
+    description: String,
+}
+
+/// Thermometer for the tests
+pub(crate) struct ExamplePlug {
+    current_state: Cell<bool>,
+    current_power: Cell<f64>,
+    name: String,
+    description: String,
+}
+
+impl From<ExampleThermometer> for Box<dyn SmartThermometer> {
+    fn from(thermometer: ExampleThermometer) -> Self {
+        Box::new(thermometer)
+    }
+}
+
+impl ExampleThermometer {
+    pub(crate) fn new<N, D>(name: N, description: D) -> Self
+    where
+        N: Into<String>,
+        D: Into<String>,
+    {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            current_temperature: Default::default(),
+        }
+    }
+
+    pub(crate) fn set_current_temperature(&self, current_temperature: f64) {
+        self.current_temperature.set(current_temperature)
+    }
+}
+
+impl From<ExamplePlug> for Box<dyn SmartPlug> {
+    fn from(plug: ExamplePlug) -> Self {
+        Box::new(plug)
+    }
+}
+
+impl ExamplePlug {
+    pub(crate) fn new<N, D>(name: N, description: D) -> Self
+    where
+        N: Into<String>,
+        D: Into<String>,
+    {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            current_state: Default::default(),
+            current_power: Default::default(),
+        }
+    }
+
+    pub(crate) fn set_current_power(&self, current_power: f64) {
+        self.current_power.set(current_power)
+    }
+
+    pub(crate) fn get_current_state(&self) -> bool {
+        self.current_state.get()
+    }
+}
+
+impl SmartDevice for ExampleThermometer {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+}
+
+impl SmartThermometer for ExampleThermometer {
+    fn current_temperature(&self) -> crate::error::Result<f64> {
+        Ok(self.current_temperature.get())
+    }
+}
+
+impl SmartDevice for ExamplePlug {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+}
+
+impl SmartPlug for ExamplePlug {
+    fn on(&self) -> crate::error::Result<()> {
+        self.current_state.set(true);
+        Ok(())
+    }
+
+    fn off(&self) -> crate::error::Result<()> {
+        self.current_state.set(false);
+        Ok(())
+    }
+
+    fn current_power(&self) -> crate::error::Result<f64> {
+        Ok(self.current_power.get())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ mod home;
 mod room;
 
 pub use crate::{
-    device::{Device, Plug, SmartDevice, Thermometer},
+    device::{Device, SmartDevice, SmartPlug, SmartThermometer},
     home::Home,
     room::Room,
 };


### PR DESCRIPTION
<!-- Please explain the changes you made -->

This will allow multiple implementations to be used for the same device type

This commit also adds ExamplePlug and ExampleThermometer with the ability to hack the internal state of this "smart devices" for tests.
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Mephistophiles/otus-smart-home/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/Mephistophiles/otus-smart-home/blob/main/CHANGELOG.md
-->

bors r+